### PR TITLE
Use option group value for checkbox field info

### DIFF
--- a/R/CastorData.R
+++ b/R/CastorData.R
@@ -665,7 +665,7 @@ CastorData <- R6::R6Class("CastorData",
         checkbox_map <- pmap(checkboxes, list) %>%
           set_names(map(., "field_variable_name")) %>%
           imap(~paste0(.$field_variable_name, "#",
-                       .$option_group.options$groupOrder))
+                       .$option_group.options$value))
 
         # the above generates duplicates
         checkbox_map[unique(names(checkbox_map))]


### PR DESCRIPTION
The checkbox ` field_info` that goes into `split_checkbox()` is created in `generateCheckboxFields()`. However, `generateCheckboxFields()` uses the option group `groupOrder`, whereas `split_checkbox()` expects and operates on the option group `value`.

This leads to problems if the `value` (which can be any number chosen by the user when setting up the Castor study) don't correspond to the `groupOrder` (which always starts at 0 and increments by 1 for each new option).

This PR swaps out `groupOrder` for `value` in `generateCheckboxFields()`. I've verified that following this change, `getStudyData()` produced the correct data frame for my particular study (with a checkbox with 4 options with values 1 through 4). So this should be a fix for #18. However, I haven't tested this solution in other situations, and I was also unable to run the {testthat} tests (missing the test credentials).