### PR TITLE
Last bug fixes

### DIFF
--- a/R/CastorData.R
+++ b/R/CastorData.R
@@ -797,6 +797,9 @@ CastorData <- R6::R6Class("CastorData",
           names(survey_instances) <- survey_names
 
           data_list[["Surveys"]] <- survey_instances
+        } else {
+          data_list[["Surveys"]] <- NULL
+
         }
       }
 

--- a/R/CastorData.R
+++ b/R/CastorData.R
@@ -825,7 +825,7 @@ CastorData <- R6::R6Class("CastorData",
         checkbox_map <- pmap(checkboxes, list) %>%
           set_names(map(., "field_variable_name")) %>%
           imap(~paste0(.$field_variable_name, "#",
-                       .$option_group.options$groupOrder))
+                       .$option_group.options$name))
 
         # the above generates duplicates
         checkbox_map[unique(names(checkbox_map))]
@@ -843,8 +843,15 @@ CastorData <- R6::R6Class("CastorData",
       if (is.null(checkbox_fields) || length(checkbox_vars) == 0)
         return(datapoints)
       else {
+        # Get the link between values and labels for each checkbox field
+        value_to_label_map <- filter(field_info, field_type == "checkbox") %>%
+          pmap(list) %>%
+          set_names(map(., "field_variable_name")) %>%
+          lapply(function(x) x$option_group.options)
+
         checkbox_data <- split_checkboxes(datapoints[checkbox_vars],
-                                          checkbox_field_info = checkbox_fields)
+                                          checkbox_field_info = checkbox_fields,
+                                          value_to_label = value_to_label_map)
         adjusted_data_points <- bind_cols(
           select(datapoints, -one_of(checkbox_vars)),
           checkbox_data)

--- a/R/CastorData.R
+++ b/R/CastorData.R
@@ -704,11 +704,10 @@ CastorData <- R6::R6Class("CastorData",
 
       if (is.null(all_data_points.df)) {
         warning("No study data available for this study.")
-        fields <- unique(field_info$field_variable_name)
         all_data_points.df <- as.list(
-          rep(NA, length(fields) + length(metadata_fields))
+          rep(NA, length(metadata_fields))
         )
-        names(all_data_points.df) <- append(fields, metadata_fields)
+        names(all_data_points.df) <- metadata_fields
         all_data_points.df <- as.data.frame(all_data_points.df)[NULL, ]
       }
 

--- a/R/CastorData.R
+++ b/R/CastorData.R
@@ -761,6 +761,8 @@ CastorData <- R6::R6Class("CastorData",
 
           names(repeating_data_instances) <- repeating_data_names
           data_list[["Repeating data"]] <- repeating_data_instances
+        } else {
+          data_list[["Repeating data"]] <- NULL
         }
 
       }

--- a/R/CastorData.R
+++ b/R/CastorData.R
@@ -347,7 +347,7 @@ CastorData <- R6::R6Class("CastorData",
       si_metadata <- unnest(spi_metadata, `_embedded.survey_instances`, names_sep = "_")
 
       # Select only relevant columns
-      selected_cols <- c("_embedded.survey_instances__embedded.survey.id",
+      selected_cols <- c("_embedded.survey_instances_id",
                          "participant_id",
                          "_embedded.survey_instances__embedded.survey.name",
                          "survey_package_name",
@@ -360,8 +360,8 @@ CastorData <- R6::R6Class("CastorData",
                          "parent_type")
 
       name_map <- c(
-        "_embedded.survey_instances__embedded.survey.id" = "survey_instance_id",
-        "_embedded.survey_instances__embedded.survey.name" = "survey_instance_name",
+        "_embedded.survey_instances_id" = "survey_instance_id",
+        "_embedded.survey_instances__embedded.survey.name" = "survey_name",
         "parent_id" = "survey_package_instance_parent_id",
         "parent_type" = "survey_package_instance_parent_type",
         "created_on.date" = "created_on",

--- a/R/CastorData.R
+++ b/R/CastorData.R
@@ -777,7 +777,7 @@ CastorData <- R6::R6Class("CastorData",
 
           # Split up in a list of dataframes per survey
           # NB: package_name is a misnomer, should be survey_name
-          survey_instances <- split(survey_instances, f = survey_instances$survey_instance_name)
+          survey_instances <- split(survey_instances, f = survey_instances$survey_name)
           survey_names <- names(survey_instances)
           # Only keep relevant fields
           survey_instances <- lapply(names(survey_instances), function(name) {

--- a/R/CastorData.R
+++ b/R/CastorData.R
@@ -772,10 +772,7 @@ CastorData <- R6::R6Class("CastorData",
         survey_fields <- attr(survey_instances, "survey_field_names")
 
         if (!is.null(survey_instances)) {
-          survey_instances <- self$adjustCheckboxFields(
-            survey_instances,
-            filter(field_metadata,
-                   field_variable_name %in% names(survey_instances)))
+          survey_variables <- names(survey_instances)
 
           # Split up in a list of dataframes per survey
           # NB: package_name is a misnomer, should be survey_name
@@ -787,6 +784,15 @@ CastorData <- R6::R6Class("CastorData",
               # Unselect all fields that belong to other repeating data instances
               dplyr::select(-all_of(discard_at(survey_fields, name) %>% unlist(use.names = F)))
           })
+
+          # Adjust checkbox fields
+          survey_instances <- lapply(survey_instances, function(survey) {
+            self$adjustCheckboxFields(
+              survey,
+              filter(field_metadata, field_variable_name %in% survey_variables)
+            )
+          })
+
           names(survey_instances) <- survey_names
 
           data_list[["Surveys"]] <- survey_instances

--- a/R/CastorData.R
+++ b/R/CastorData.R
@@ -413,17 +413,16 @@ CastorData <- R6::R6Class("CastorData",
       survey_inst_fields <- c("field_id", "survey_instance_id", "field_value",
                               "participant_id", "survey_name")
 
-      survey_data <- rename(
+      survey_data <-
         spread(
           distinct(
             select(survey_instances, survey_instance_id, participant_id, field_id,
                    field_value)),
-          field_id, field_value),
-        Participant_ID = participant_id)
+          field_id, field_value) %>%
+        select(-participant_id)
 
       if (!is.null(id_to_field_name_)) {
-        survey_data <- rename_at(survey_data, vars(-Participant_ID,
-                                    -survey_instance_id),
+        survey_data <- rename_at(survey_data, vars(-survey_instance_id),
                   ~unlist(id_to_field_name_, recursive = FALSE)[.])}
 
 

--- a/R/CastorData.R
+++ b/R/CastorData.R
@@ -687,27 +687,22 @@ CastorData <- R6::R6Class("CastorData",
           all_data_points.df <- bind_rows(study_data)
         }
       } else {
+        all_data_points.df <- NULL
+      }
+
+      if (is.null(all_data_points.df)) {
         all_data_points.df <- rename(
           select(
             participant_metadata,
             participant_id,
             Randomization_Group = randomization_group,
             Randomization_Group_Name = randomization_group_name,
-            Randomized_On = randomized_on.date,
+            Randomized_On = randomized_on,
             Site_Abbreviation = `_embedded.site.abbreviation`,
             Participant_Creation = created_on.date
           ),
           Participant_ID = participant_id
         )
-      }
-
-      if (is.null(all_data_points.df)) {
-        warning("No study data available for this study.")
-        all_data_points.df <- as.list(
-          rep(NA, length(metadata_fields))
-        )
-        names(all_data_points.df) <- metadata_fields
-        all_data_points.df <- as.data.frame(all_data_points.df)[NULL, ]
       }
 
       adjusted_data_points.df <- self$adjustTypes(

--- a/R/utils.R
+++ b/R/utils.R
@@ -61,7 +61,7 @@ map_value_label = function(value_vector, link_list) {
 
 
 #' @importFrom stats setNames
-split_checkbox <- function(values, field_info, sep_ = ";") {
+split_checkbox <- function(values, field_info, value_to_label, sep_ = ";") {
   #cat("checkbox values:\n")
   #print(values)
   #cat("checkbox field info:\n")
@@ -78,6 +78,17 @@ split_checkbox <- function(values, field_info, sep_ = ";") {
   } else {
     values <- rep(NA, num_vals)
   }
+
+  # Loop over each value in each column
+  # Replace value with label
+  # If value is NA, replace with NA
+  values <- map(values, function(x)
+    map(x, function(y)
+      ifelse(
+        is.na(y),
+        NA_character_,
+        value_to_label %>% filter(value == y) %>% pull(name)
+      )) %>% unlist())
 
   field <- names(field_info)
 
@@ -111,10 +122,10 @@ split_checkbox <- function(values, field_info, sep_ = ";") {
   select(checkbox_result, one_of(field_info[[field]]))
 }
 
-split_checkboxes <- function(checkbox_data, checkbox_field_info, sep = ";") {
+split_checkboxes <- function(checkbox_data, checkbox_field_info, value_to_label, sep = ";") {
   bind_cols(
     imap(checkbox_data, function(field_data, field) {
-      split_checkbox(field_data, checkbox_field_info[field], sep)
+      split_checkbox(field_data, checkbox_field_info[field], value_to_label[[field]], sep)
     })
   )
 }

--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ study <- castor_api$getStudyData(example_study_id)
 <tr>
 <td>
 
-|      | Participant_ID | Site_Abbreviation | Randomization_Group | Participant_Creation | ic_date    | ic_versions#1 | ic_versions#0 | ic_main_version | ic_language#0 | ic_language#1 |
-|:-----|:---------------|:------------------|:--------------------|:---------------------|:-----------|:--------------|:--------------|:----------------|:--------------|:--------------|
-| 1    | 110001         | FGV               | NA                  | 2021-06-22 09:51:49  | 2021-06-22 | TRUE          | FALSE         | 2.5             | FALSE         | FALSE         |
-| 2    | 110002         | FGV               | NA                  | 2021-06-22 09:59:01  | NA         | FALSE         | FALSE         | NA              | FALSE         | FALSE         |
-| NA   | NA             | NA                | NA                  | NA                   | NA         | NA            | NA            | NA              | NA            | NA            |
-| NA.1 | NA             | NA                | NA                  | NA                   | NA         | NA            | NA            | NA              | NA            | NA            |
-| NA.2 | NA             | NA                | NA                  | NA                   | NA         | NA            | NA            | NA              | NA            | NA            |
+|      | Participant_ID | Site_Abbreviation | Randomization_Group | Participant_Creation | ic_date    | ic_versions#Other | ic_versions#Main study CF | ic_main_version | ic_language#English | ic_language#Dutch |
+|:-----|:---------------|:------------------|:--------------------|:---------------------|:-----------|:------------------|:--------------------------|:----------------|:--------------------|:------------------|
+| 1    | 110001         | FGV               | NA                  | 2021-06-22 09:51:49  | 2021-06-22 | FALSE             | FALSE                     | 2.5             | FALSE               | FALSE             |
+| 2    | 110002         | FGV               | NA                  | 2021-06-22 09:59:01  | NA         | FALSE             | FALSE                     | NA              | FALSE               | FALSE             |
+| NA   | NA             | NA                | NA                  | NA                   | NA         | NA                | NA                        | NA              | NA                  | NA                |
+| NA.1 | NA             | NA                | NA                  | NA                   | NA         | NA                | NA                        | NA              | NA                  | NA                |
+| NA.2 | NA             | NA                | NA                  | NA                   | NA         | NA                | NA                        | NA              | NA                  | NA                |
 
 </td>
 <td>
@@ -139,9 +139,11 @@ study <- castor_api$getStudyData(example_study_id)
 <tr>
 <td>
 
-| survey_instance_id                   | Participant_ID | package_name | SF12_12 | SF12_2 | SF12_1    | VAS   | SF12_3 |
-|:-------------------------------------|:---------------|:-------------|:--------|:-------|:----------|:------|:-------|
-| 4FF130AD-274C-4C8F-A4A0-A7816A5A88E9 | 110001         | QOL Survey   | Rarely  | Mostly | Excellent | 85.00 | Mostly |
+| survey_instance_id                   | participant_id | survey_name | survey_package_name     | survey_package_instance_id           | created_on                 | created_by                           | sent_on                    | finished_on                | survey_package_instance_parent_id | survey_package_instance_parent_type | SF12_12 | SF12_2 | SF12_1    | VAS   | SF12_3 |
+|:-------------------------------------|:---------------|:------------|:------------------------|:-------------------------------------|:---------------------------|:-------------------------------------|:---------------------------|:---------------------------|:----------------------------------|:------------------------------------|:--------|:-------|:----------|:------|:-------|
+| 4FF130AD-274C-4C8F-A4A0-A7816A5A88E9 | 110001         | QOL Survey  | My first survey package | 0761A9BA-9802-483D-8EB3-D07233A56F2B | 2021-06-22 10:12:19.000000 | B23ABCC4-3A53-FB32-7B78-3960CC907F25 | 2021-06-22 10:12:19.000000 | 2021-06-22 10:12:44.000000 |                                   | 0                                   | Rarely  | Mostly | Excellent | 85.00 | Mostly |
+| B99F0082-1B20-456B-8D4D-47D16867B211 | 110001         | QOL Survey  | My first survey package | 5B3FE56F-89FA-4C6D-A638-E8FA46113EB0 | 2021-06-22 10:13:01.000000 | B23ABCC4-3A53-FB32-7B78-3960CC907F25 | 2021-06-22 10:13:01.000000 | NA                         |                                   | 0                                   | NA      | NA     | NA        | NA    | NA     |
+| 29FD41EF-46F1-4DEA-A372-F38FC2C0C9C2 | 110001         | QOL Survey  | My first survey package | EBBB77D0-56A2-49C7-9333-A27C17FA5D95 | 2021-09-24 13:12:45.000000 | B23ABCC4-3A53-FB32-7B78-3960CC907F25 | 2021-09-24 13:12:45.000000 | NA                         |                                   | 0                                   | NA      | NA     | NA        | NA    | NA     |
 
 </td>
 </tr>


### PR DESCRIPTION
Fixed some bugs for the v2.0.0 release:
- Survey data fields are now first filtered, then cleaned. Cleaning changes the names of checkbox fields, after which they could not be filtered anymore.
- Fixed left_join error of survey_instance data on survey_instance metadata. Tried to left_join survey_id on survey_instance_id, while these should both be survey_instance_id
- If no study information exist (i.e. there are no filled in study forms), then getStudyData returns bare-bones participant information
- Added NULL to getStudyData in the list when there are no surveys or no repeating data instances
- Checkbox fields now are named with their label in the variable name, instead of their value
- Removed double column participant id when returning survey data

With these fixes, #34 is now fixed