### PR TITLE
Force checkbox name to remain as is

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -97,7 +97,8 @@ split_checkbox <- function(values, field_info, value_to_label, sep_ = ";") {
       bind_rows(
         lapply(values, function(value) {
           checkboxes <- as.data.frame(split(rep(TRUE, length(value)),
-                                            paste0(field, ".", value)))
+                                            paste0(field, ".", value)),
+                                      check.names = FALSE)
           if (nrow(checkboxes) > 0)
             checkboxes
           else


### PR DESCRIPTION
Proposed fix for #46.

https://github.com/castoredc/castoRedc/blob/5b50bc0f036f2674aa3e59a520690a7f2b134ea8/R/utils.R#L99-L100

`as.data.frame()` will replace any spaces in the list names with a `.`. The resulting column names in `checkbox_result` will therefore no longer match those in `field_info`. 

https://github.com/castoredc/castoRedc/blob/5b50bc0f036f2674aa3e59a520690a7f2b134ea8/R/utils.R#L112-L117

Because they no longer match, a new set of columns *with the original names* and all values set to `FALSE` are created by the snippet above.

https://github.com/castoredc/castoRedc/blob/5b50bc0f036f2674aa3e59a520690a7f2b134ea8/R/utils.R#L119-L122

Finally,  this snippet discards the correct columns (with the fixed names), and retains only the all-`FALSE` columns (with the original names).

All of this can be fixed by calling as.data.frame() with the `check.names = FALSE` argument, to force the original names to be retained. Because there's "data" contained within the names here (i.e. which checkbox was ticked), automatically fixing them to be proper columns names might not be a good idea here. 

I've confirmed this fixes the issue for me, but it might have other unwanted downstream effects I can't oversee (like not being able to subset the data frame columns with `$` without enclosing them in backticks, as the column names may now have spaces in them).